### PR TITLE
Allow access to raw brightness value

### DIFF
--- a/src/brightness.rs
+++ b/src/brightness.rs
@@ -3,7 +3,7 @@
 /// Struct that holds display brightness
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Brightness {
-    pub(crate) brightness: u8,
+    pub brightness: u8,
 }
 
 impl Default for Brightness {


### PR DESCRIPTION
Thanks for the driver, it's been a great head start when trying to make use of this device.

Would it be possible to expose access to the inner brightness value? 

For context, I'm trying to hack together an async version of the driver so that I can efficiently use it with embassy. I've got it mostly working but at the minute I'm forced use raw brightness values e.g. -

```
command_wrapper
        .send(Command::DisplayBrightness(0x5F))
        .unwrap();
```

An alternative change (happy to make it), would be to change `DisplayBrightness` to accept `Brightness` if you'd prefer that?