### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Rust implementation SPI 4-wire driver for the [`Gc9a01`](https://crates.io/crate
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.0] - 2024-09-02
+
+### Changed
+
+- change: fn brightness::custom move from private to public
+
 ## [0.2.1] - 2024-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Rust implementation SPI 4-wire driver for the [`Gc9a01`](https://crates.io/crate
 
 - change: fn brightness::custom move from private to public
 
+### Fixed
+
+- clippy: allow clippy::needless_pass_by_ref_mut for driver reset
+- fix: get_screen_rotation as mutable reference, but not used mutably
+- clippy: src/command.rs allow clippy::doc_markdow
+
 ## [0.2.1] - 2024-04-20
 
 ### Added
@@ -36,7 +42,8 @@ Rust implementation SPI 4-wire driver for the [`Gc9a01`](https://crates.io/crate
 - Move playgrounds outside the library project.
 
 <!-- next-url -->
-[unreleased]: https://github.com/IniterWorker/gc9a01/compare/0.2.1...HEAD
+[unreleased]: https://github.com/IniterWorker/gc9a01/compare/0.3.0...HEAD
 
+[0.3.0]: https://github.com/IniterWorker/gc9a01/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/IniterWorker/gc9a01/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/IniterWorker/gc9a01/compare/0.1.0...0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gc9a01-rs"
 categories = ["embedded", "no-std"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Walter Bonetti <walter.bonetti@epitech.eu>"

--- a/src/brightness.rs
+++ b/src/brightness.rs
@@ -28,7 +28,16 @@ impl Brightness {
     /// Brightest predefined brightness level
     pub const BRIGHTEST: Self = Self::custom(0xFF);
 
-    const fn custom(brightness: u8) -> Self {
+    /// Create a new `Brightness` from a custom raw input
+    ///
+    /// # Notes
+    ///
+    /// It should be checked what is the relationship between this written value and output brightness of the display.
+    /// This relationship is defined on the display module specification.
+    /// In principle, the relationship is that `00h` value means the lowest brightness and `FFh` value means the highest brightness.
+    ///
+    #[must_use]
+    pub const fn custom(brightness: u8) -> Self {
         Self { brightness }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::doc_markdown)]
 #![allow(clippy::match_same_arms)]
 //! Commands
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -30,6 +30,7 @@ where
     /// # Errors
     ///
     /// See `OutputPin` definition for more information.
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn reset<RST, DELAY>(&mut self, rst: &mut RST, delay: &mut DELAY) -> Result<(), RST::Error>
     where
         RST: OutputPin,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -233,7 +233,7 @@ where
     }
 
     /// Get screen rotation
-    pub fn get_screen_rotation(&mut self) -> DisplayRotation {
+    pub const fn get_screen_rotation(&self) -> DisplayRotation {
         self.display_rotation
     }
 


### PR DESCRIPTION
## [0.3.0] - 2024-09-02

### Changed

- change: fn brightness::custom move from private to public

### Fixed

- clippy: allow clippy::needless_pass_by_ref_mut for driver reset
- fix: get_screen_rotation as mutable reference, but not used mutably
- clippy: src/command.rs allow clippy::doc_markdow
